### PR TITLE
Show all shipping methods once one is selected

### DIFF
--- a/Model/Quote/Result/Builder/ExtractShippingMethods.php
+++ b/Model/Quote/Result/Builder/ExtractShippingMethods.php
@@ -34,9 +34,17 @@ class ExtractShippingMethods
     public function extract(CartInterface $quote): array
     {
         $shippingMethods = [];
+        $quote->getShippingAddress()->requestShippingRates();
         $shippingRates = $quote->getShippingAddress()->getGroupedAllShippingRates();
+        $shippingMethodSet = [];
         foreach ($shippingRates as $carrierRates) {
             foreach ($carrierRates as $rate) {
+                // Filtering out the same shipping method
+                if (isset($shippingMethodSet[$rate->getCode()])) {
+                    continue;
+                }
+                $shippingMethodSet[$rate->getCode()] = true;
+
                 $shippingMethods[] = $this->shippingMethodConverter->modelToDataObject(
                     $rate,
                     $quote->getQuoteCurrencyCode()


### PR DESCRIPTION
When a shipping rate is selected on the quote, the current way of getting available shipping methods will only return the selected shipping method in the array of available shipping methods. This fix will ensure that all available shipping methods are always shown.

Not sure this is the best way to fix the aforementioned issue.