### PR TITLE
Set child line item's qty to match parent's

### DIFF
--- a/Model/Quote/Result/Builder.php
+++ b/Model/Quote/Result/Builder.php
@@ -128,6 +128,8 @@ class Builder
                 $parentItem = $item->getParentItem();
                 $item->getExtensionAttributes()->setParentItemId($parentItem->getId());
                 $item->getExtensionAttributes()->setTaxDetails($parentItem->getExtensionAttributes()->getTaxDetails());
+                $item->setQty($parentItem->getQty());
+                $item->setPrice($parentItem->getPrice());
                 $parentProduct = $parentItem->getProduct();
             }
             $product = $item->getProduct();


### PR DESCRIPTION
Fixes issue where when a product that has variants is added to the cart with a quantity greater than 1, in the checkout the quantity will be set to 1 after entering shipping