### PR TITLE
Set shipping assignment after clearing addresses

### DIFF
--- a/Model/Quote/SetQuoteAddresses.php
+++ b/Model/Quote/SetQuoteAddresses.php
@@ -83,6 +83,7 @@ class SetQuoteAddresses implements SetQuoteAddressesInterface
         if ($billingAddress === null) {
             $quote->removeAddress($quote->getBillingAddress()->getId());
             $quote->removeAddress($quote->getShippingAddress()->getId());
+            $quote->getExtensionAttributes()->setShippingAssignments([]);
             return $this->quoteResultBuilder->createSuccessResult($quote);
         }
         $shippingAddress = $shippingAddress === null || $shippingAddress->getSameAsBilling()


### PR DESCRIPTION
Removing the addresses from the quote will break on not allowing an empty shipping address when updating unless the shipping assignments are remade with the empty addresses.