### PR TITLE
Removes api token from default scope config

### DIFF
--- a/Block/System/Config/Form/Field/ApiNote.php
+++ b/Block/System/Config/Form/Field/ApiNote.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bold\Checkout\Block\System\Config\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+/**
+ * Bold Integration api note field.
+ */
+class ApiNote extends Field
+{
+    /**
+     * @inheritDoc
+     */
+    protected function _renderValue(AbstractElement $element)
+    {
+        $text = __('Please switch website scopes first to add an API Token.');
+        $element->setText($text);
+
+        return parent::_renderValue($element);
+    }
+}

--- a/Observer/Checkout/CheckoutSectionSave.php
+++ b/Observer/Checkout/CheckoutSectionSave.php
@@ -58,7 +58,7 @@ class CheckoutSectionSave implements ObserverInterface
     {
         $event = $observer->getEvent();
         $websiteId = (int)$event->getWebsite();
-        if (!$this->config->isCheckoutEnabled($websiteId)) {
+        if (!$this->config->isCheckoutEnabled($websiteId) || $websiteId === 0) {
             return;
         }
         $this->config->setShopId($websiteId, null);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -38,7 +38,7 @@
                         <field id="type">1</field>
                     </depends>
                 </field>
-                <field id="api_token" translate="label" type="obscure" sortOrder="20" showInDefault="1"
+                <field id="api_token" translate="label" type="obscure" sortOrder="20" showInDefault="0"
                        showInWebsite="1">
                     <label>API Token</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
@@ -46,6 +46,10 @@
                     <comment>API token used to communicate with the Bold Checkout APIs. Obtain in the Bold Account
                         Center.
                     </comment>
+                </field>
+                <field id="api_token_note" translate="label" type="note" sortOrder="25" showInDefault="1">
+                    <label>API Token</label>
+                    <frontend_model>Bold\Checkout\Block\System\Config\Form\Field\ApiNote</frontend_model>
                 </field>
                 <field id="integration_email" translate="select" type="select" sortOrder="30" showInDefault="1"
                        showInWebsite="1">
@@ -64,7 +68,7 @@
                     <validate>required-entry</validate>
                     <comment><![CDATA[Please do not change.]]></comment>
                 </field>
-                <field id="integration_status" translate="label" type="note" sortOrder="60" showInDefault="1" showInWebsite="1">
+                <field id="integration_status" translate="label" type="note" sortOrder="60" showInDefault="0" showInWebsite="1">
                     <label>Bold Integration Status</label>
                     <frontend_model>Bold\Checkout\Block\System\Config\Form\Field\Status</frontend_model>
                     <comment><![CDATA[In case the status is 'Not Found', please re-save configuration.


### PR DESCRIPTION
This removes the ability to set an api token on the default website scope which would cause downstream issues. When you are looking at the config under the default config this is now shown.
![image](https://github.com/bold-commerce/adobe-commerce-bold-checkout/assets/3497093/342952cd-3c89-46f5-b37a-ce465431c1db)
