### PR TITLE
Google Analytics Identity

### DIFF
--- a/Observer/Checkout/RedirectToBoldCheckoutObserver.php
+++ b/Observer/Checkout/RedirectToBoldCheckoutObserver.php
@@ -100,6 +100,13 @@ class RedirectToBoldCheckoutObserver implements ObserverInterface
             $checkoutApiUrl = rtrim($this->config->getCheckoutUrl($websiteId), '/') . '/bold_platform/';
             $checkoutUrl = $checkoutApiUrl . $shopName . '/experience/resume?public_order_id=' . $orderId
                 . '&token=' . $token;
+
+            $ga = $request->getCookie('_ga');
+            if(!empty($ga)) {
+                $ga = explode('.', $ga, 3);
+                $_ga = array_pop($ga);
+                $checkoutUrl = $checkoutUrl . '&_ga=' . $_ga;
+            }
             $observer->getControllerAction()->getResponse()->setRedirect($checkoutUrl);
         } catch (Exception $exception) {
             $this->logger->critical($exception);


### PR DESCRIPTION
The way we enter checkout from a store doesn't allow google analytics to automatically pass params along to the checkout. This means that the user will not be linked from the store to the checkout as the same. 

The `_ga` cookie will be formatted something like `GA1.1.1143069538.1694542174`
We only need the last two sets of numbers to pass along to the checkout as a param `_ga` to keep the user tracked properly.