### PR TITLE
Payment Booster compatibility for FireCheckout

### DIFF
--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -7,6 +7,9 @@
     <event name="controller_action_predispatch_onestepcheckout_index_index">
         <observer name="redirect_to_bold_checkout" instance="Bold\Checkout\Observer\Checkout\RedirectToBoldCheckoutObserver"/>
     </event>
+    <event name="controller_action_predispatch_firecheckout_index_index">
+        <observer name="redirect_to_bold_checkout" instance="Bold\Checkout\Observer\Checkout\RedirectToBoldCheckoutObserver"/>
+    </event>
     <event name="shortcut_buttons_container">
         <observer name="bold_checkout_parallel_checkout_button" instance="Bold\Checkout\Observer\Checkout\AddParallelCheckoutButton"/>
     </event>


### PR DESCRIPTION
Adds event listener for the FireCheckout controller predispatch to load required data for Bold's Payment Booster iframe. 

<img width="500" alt="image" src="https://github.com/bold-commerce/adobe-commerce-bold-checkout/assets/114614923/69dd45ec-c90d-48fb-8a9f-0019c70aea52">
