### PR TITLE
[HOTFIX] Fix missing variable and trailing comma

### DIFF
--- a/Block/System/Config/Form/Field/Location.php
+++ b/Block/System/Config/Form/Field/Location.php
@@ -15,6 +15,7 @@ class Location extends Select
     /**
      * @var InstalledModulesProvider
      */
+    protected $installedModulesProvider;
     
     /**
      * @param Context $context
@@ -22,7 +23,7 @@ class Location extends Select
      */
     public function __construct(
         Context                  $context,
-        InstalledModulesProvider $installedModulesProvider,
+        InstalledModulesProvider $installedModulesProvider
     )
     {
         parent::__construct($context);

--- a/Model/ModuleInfo/InstalledModulesProvider.php
+++ b/Model/ModuleInfo/InstalledModulesProvider.php
@@ -42,6 +42,6 @@ class InstalledModulesProvider
      */
     public function isPayPalFlowInstalled(): bool
     {
-        return array_contains($this->moduleList, self::PAYPAL_FLOW_MODULE);
+        return in_array(self::PAYPAL_FLOW_MODULE, $this->moduleList);
     }
 }


### PR DESCRIPTION
* Fixed missing variable
* Fixed trailing comma breaking PHP <8 version
* Fixed missing builtin `array_contains`