### PR TITLE
Fix module breaking on first install

### DIFF
--- a/view/adminhtml/templates/system/config/form/field/onboard_banner.phtml
+++ b/view/adminhtml/templates/system/config/form/field/onboard_banner.phtml
@@ -7,18 +7,18 @@ $bannerData = $block->getBannerData();
 <?php if ($bannerData): ?>
     <div id="bold-checkout-onboard">
         <div>
-            <h2><?= $escaper->escapeHtml($bannerData['header']) ?></h2>
-            <p><?= $escaper->escapeHtml($bannerData['text']) ?></p>
+            <h2><?= $escaper->escapeHtml($bannerData->header) ?></h2>
+            <p><?= $escaper->escapeHtml($bannerData->text) ?></p>
         </div>
 
         <button
             type="button"
             onclick="window.open (
-                '<?= $escaper->escapeUrl($bannerData['link']) ?>',
+                '<?= $escaper->escapeUrl($bannerData->link) ?>',
                 'Bold Account Center',
                 'width=1400,height=950')
             ">
-            <?= $escaper->escapeHtml($bannerData['button_text']) ?>
+            <?= $escaper->escapeHtml($bannerData->button_text) ?>
         </button>
     </div>
 <?php endif ?>


### PR DESCRIPTION
Recent PR relating to onboarding banner broke the module for fresh installs. It was using a client which required the shop identifier to have been set in the config but which only gets sets after the config has been saved with Bold Checkout enabled. 

Switch to using native Magento Http client instead and remove requirement for the shop identifier in the Platform connector endpoint call. 