### PR TITLE
adds order resume client

### DIFF
--- a/Model/Order/ResumeOrder.php
+++ b/Model/Order/ResumeOrder.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Bold\Checkout\Model\Order;
+
+use Bold\Checkout\Api\Http\ClientInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\Data\CartInterface;
+
+/**
+ * Resume order on Bold side.
+ */
+class ResumeOrder
+{
+    private const RESUME_URL = '/checkout/orders/{{shopId}}/resume';
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @param ClientInterface $client
+     */
+    public function __construct(
+        ClientInterface $client,
+    ) {
+        $this->client = $client;
+    }
+
+    /**
+     * Resume order on bold side.
+     *
+     * @param CartInterface $quote
+     * @param string $publicOrderId
+     * @return array
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function resume(CartInterface $quote, string $publicOrderId): array
+    {
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+        $body = [
+            'public_order_id' => $publicOrderId
+        ];
+
+        $orderData = $this->client->post($websiteId, self::RESUME_URL, $body)->getBody();
+        $publicOrderId = $orderData['data']['public_order_id'] ?? null;
+        if (!$publicOrderId) {
+            throw new LocalizedException(__('Cannot resume order'));
+        }
+
+        return $orderData;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -52,6 +52,11 @@
             <argument name="client" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
         </arguments>
     </type>
+    <type name="Bold\Checkout\Model\Order\ResumeOrder">
+        <arguments>
+            <argument name="client" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
+        </arguments>
+    </type>
     <type name="Bold\Checkout\Model\Payment\Gateway\Service">
         <arguments>
             <argument name="httpClient" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>


### PR DESCRIPTION
This adds a new resume endpoint which will be used by the meta flow frontend to refresh the jwt token when it is expired.