### PR TITLE
Remove dependency on enabling Checkout before the Platform Connector Integration can be activated

### DIFF
--- a/Observer/Checkout/CheckoutSectionSave.php
+++ b/Observer/Checkout/CheckoutSectionSave.php
@@ -68,9 +68,6 @@ class CheckoutSectionSave implements ObserverInterface
     {
         $event = $observer->getEvent();
         $websiteId = (int)$event->getWebsite() ?: (int)$this->storeManager->getWebsite(true)->getId();
-        if (!$this->config->isCheckoutEnabled($websiteId)) {
-            return;
-        }
         $this->config->setShopId($websiteId, null);
         $shopInfo = $this->client->get($websiteId, self::SHOP_INFO_URL);
         if ($shopInfo->getErrors()) {


### PR DESCRIPTION
With the current onboarding process you need to have Bold Checkout enabled in the module config in order for the integration to be created in Magento. This puts the checkout in a temporary broken state while the user completes the onboarding setup and integration activation. 

This PR removes that dependancy allowing for the integration to be created while Bold Checkout is disabled allowing users to complete the installation setup before enabling checkout. 

![image](https://github.com/bold-commerce/adobe-commerce-bold-checkout/assets/114614923/e05c538a-2832-494c-b711-409526a1c51c)


![image](https://github.com/bold-commerce/adobe-commerce-bold-checkout/assets/114614923/ed9b7a09-a677-4cc9-969e-a14686508bba)
