### PR TITLE
Add endpoint for setting shipping address only

### DIFF
--- a/Api/Quote/SetQuoteAddressesInterface.php
+++ b/Api/Quote/SetQuoteAddressesInterface.php
@@ -26,4 +26,16 @@ interface SetQuoteAddressesInterface
         AddressInterface $billingAddress = null,
         AddressInterface $shippingAddress = null
     ): ResultInterface;
+
+    /**
+     * @param string $shopId
+     * @param int $cartId
+     * @param \Magento\Quote\Api\Data\AddressInterface|null $shippingAddress
+     * @return \Bold\Checkout\Api\Data\Quote\ResultInterface
+     */
+    public function setShippingAddress(
+        string $shopId,
+        int $cartId,
+        AddressInterface $shippingAddress = null
+    ): ResultInterface;
 }

--- a/Model/Quote/SetQuoteAddresses.php
+++ b/Model/Quote/SetQuoteAddresses.php
@@ -92,6 +92,26 @@ class SetQuoteAddresses implements SetQuoteAddressesInterface
             ? $billingAddress
             : $shippingAddress;
         $quote->getBillingAddress()->addData($billingAddress->getData());
+
+        return $this->setShippingAddressOnQuote($quote, $shippingAddress);
+    }
+
+    public function setShippingAddress(
+        string $shopId,
+        int $cartId,
+        AddressInterface $shippingAddress = null
+    ): ResultInterface {
+        try {
+            $quote = $this->loadAndValidate->load($shopId, $cartId);
+        } catch (LocalizedException $e) {
+            return $this->quoteResultBuilder->createErrorResult($e->getMessage());
+        }
+
+        return $this->setShippingAddressOnQuote($quote, $shippingAddress);
+    }
+
+    private function setShippingAddressOnQuote($quote, $shippingAddress): ResultInterface
+    {
         if (!$quote->isVirtual()) {
             $quote->getShippingAddress()->addData($shippingAddress->getData());
             $shippingAssignment = $this->shippingAssignmentProcessor->create($quote);

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -6,6 +6,12 @@
             <resource ref="Magento_Cart::manage"/>
         </resources>
     </route>
+    <route method="POST" url="/V1/shops/:shopId/cart/:cartId/shippingAddress">
+        <service class="Bold\Checkout\Api\Quote\SetQuoteAddressesInterface" method="setShippingAddress"/>
+        <resources>
+            <resource ref="Magento_Cart::manage"/>
+        </resources>
+    </route>
     <route method="POST" url="/V1/shops/:shopId/cart/:cartId/shippingMethod">
         <service class="Bold\Checkout\Api\Quote\SetQuoteShippingMethodInterface" method="setShippingMethod"/>
         <resources>


### PR DESCRIPTION
Added a new endpoint specifically for setting only the shipping address.

The endpoint for setting both addresses would set the billing address to null if not included in the request body and did not work for what we needed with the estimate shipping logic from the platform connector. 