### PR TITLE
Error message after updating to the latest composer packages

### DIFF
--- a/Api/Http/ClientInterface.php
+++ b/Api/Http/ClientInterface.php
@@ -15,7 +15,7 @@ interface ClientInterface
      *
      * @param int $websiteId
      * @param string $url
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      * @throws \Exception
      */
     public function get(int $websiteId, string $url): ResultInterface;
@@ -26,7 +26,7 @@ interface ClientInterface
      * @param int $websiteId
      * @param string $url
      * @param array|null $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      * @throws \Exception
      */
     public function post(int $websiteId, string $url, array $data): ResultInterface;
@@ -37,7 +37,7 @@ interface ClientInterface
      * @param int $websiteId
      * @param string $url
      * @param array|null $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      * @throws \Exception
      */
     public function put(int $websiteId, string $url, array $data): ResultInterface;
@@ -48,7 +48,7 @@ interface ClientInterface
      * @param int $websiteId
      * @param string $url
      * @param array|null $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      * @throws \Exception
      */
     public function patch(int $websiteId, string $url, array $data): ResultInterface;
@@ -59,7 +59,7 @@ interface ClientInterface
      * @param int $websiteId
      * @param string $url
      * @param array $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      * @throws \Exception
      */
     public function delete(int $websiteId, string $url, array $data): ResultInterface;

--- a/Model/Customer/EmailValidator.php
+++ b/Model/Customer/EmailValidator.php
@@ -100,7 +100,7 @@ class EmailValidator implements CustomerEmailValidatorInterface
      * Build error result data model.
      *
      * @param Phrase $message
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\CustomerEmailValidator\ResultInterface
      */
     public function getErrorResult(Phrase $message): ResultInterface
     {

--- a/Model/Http/Client/Command/DeleteCommand.php
+++ b/Model/Http/Client/Command/DeleteCommand.php
@@ -59,7 +59,7 @@ class DeleteCommand
      * @param string $url
      * @param array $headers
      * @param array $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      */
     public function execute(int $websiteId, string $url, array $headers, array $data): ResultInterface
     {

--- a/Model/Http/Client/Command/GetCommand.php
+++ b/Model/Http/Client/Command/GetCommand.php
@@ -49,7 +49,7 @@ class GetCommand
      * @param int $websiteId
      * @param string $url
      * @param array $headers
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      */
     public function execute(int $websiteId, string $url, array $headers): ResultInterface
     {

--- a/Model/Http/Client/Command/PatchCommand.php
+++ b/Model/Http/Client/Command/PatchCommand.php
@@ -59,7 +59,7 @@ class PatchCommand
      * @param string $url
      * @param array $headers
      * @param array $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      */
     public function execute(int $websiteId, string $url, array $headers, array $data): ResultInterface
     {

--- a/Model/Http/Client/Command/PostCommand.php
+++ b/Model/Http/Client/Command/PostCommand.php
@@ -59,7 +59,7 @@ class PostCommand
      * @param string $url
      * @param array $headers
      * @param array $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      */
     public function execute(int $websiteId, string $url, array $headers, array $data): ResultInterface
     {

--- a/Model/Http/Client/Command/PutCommand.php
+++ b/Model/Http/Client/Command/PutCommand.php
@@ -59,7 +59,7 @@ class PutCommand
      * @param string $url
      * @param array $headers
      * @param array $data
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Http\Client\ResultInterface
      */
     public function execute(int $websiteId, string $url, array $headers, array $data): ResultInterface
     {

--- a/Model/Order/PlaceOrder.php
+++ b/Model/Order/PlaceOrder.php
@@ -141,7 +141,7 @@ class PlaceOrder implements PlaceOrderInterface
      * Build validation error response.
      *
      * @param string $message
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\PlaceOrder\ResultInterface
      */
     private function getValidationErrorResponse(string $message): ResultInterface
     {

--- a/Model/Order/UpdatePayment.php
+++ b/Model/Order/UpdatePayment.php
@@ -134,7 +134,7 @@ class UpdatePayment implements UpdatePaymentInterface
      * Build validation error response.
      *
      * @param string $message
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Order\Payment\ResultInterface
      */
     private function getValidationErrorResponse(string $message): ResultInterface
     {

--- a/Model/Quote/GetQuoteInventoryData.php
+++ b/Model/Quote/GetQuoteInventoryData.php
@@ -129,7 +129,7 @@ class GetQuoteInventoryData implements GetQuoteInventoryDataInterface
      * Build validation error response.
      *
      * @param string $error
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Quote\Inventory\ResultInterface
      */
     private function buildErrorResponse(string $error): ResultInterface
     {

--- a/Model/Quote/Result/Builder.php
+++ b/Model/Quote/Result/Builder.php
@@ -85,7 +85,7 @@ class Builder
      * Build quote result.
      *
      * @param CartInterface $quote
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Quote\ResultInterface
      */
     public function createSuccessResult(CartInterface $quote): ResultInterface
     {
@@ -105,7 +105,7 @@ class Builder
      * @param string $error
      * @param int $code
      * @param string $type
-     * @return ResultInterface
+     * @return Bold\Checkout\Api\Data\Quote\ResultInterface
      */
     public function createErrorResult(
         string $error,


### PR DESCRIPTION
A merchant discovered that making requests to Magento's SOAP endpoints was being met with the response `Error message: LogicException: The "ResultInterface" class doesn't exist and the namespace must be specified.` Updating docblock references to `ResultInterface` to use fully qualified names resolves the issue.