### PR TITLE
Save quote on address update for self-hosted

### DIFF
--- a/Model/Quote/SetQuoteAddresses.php
+++ b/Model/Quote/SetQuoteAddresses.php
@@ -82,9 +82,7 @@ class SetQuoteAddresses implements SetQuoteAddressesInterface
             $quote->removeAddress($quote->getShippingAddress()->getId());
             $quote->setDataChanges(true);
             $quote->collectTotals();
-            if (!$this->config->isCheckoutTypeSelfHosted((int)$quote->getStore()->getWebsiteId())) {
-                $this->quoteResource->save($quote);
-            }
+            $this->quoteResource->save($quote);
             $quote->getExtensionAttributes()->setShippingAssignments([]);
             return $this->quoteResultBuilder->createSuccessResult($quote);
         }
@@ -101,9 +99,7 @@ class SetQuoteAddresses implements SetQuoteAddressesInterface
         }
         $quote->setDataChanges(true);
         $quote->collectTotals();
-        if (!$this->config->isCheckoutTypeSelfHosted((int)$quote->getStore()->getWebsiteId())) {
-            $this->quoteResource->save($quote);
-        }
+        $this->quoteResource->save($quote);
         return $this->quoteResultBuilder->createSuccessResult($quote);
     }
 }


### PR DESCRIPTION
When setting addresses the quote was only being saved on the platform for Bold Hosted checkouts which caused issues with Payment Booster. 

With the recent optimization changes this check can be removed so we save the quote for all cart types. 