### PR TITLE
Payment Booster patch for Magento versions <= 2.3.4

### DIFF
--- a/Model/Config/Source/CheckoutTypeSource.php
+++ b/Model/Config/Source/CheckoutTypeSource.php
@@ -17,10 +17,10 @@ class CheckoutTypeSource implements OptionSourceInterface
     public function toOptionArray(): array
     {
         return [
-            ['value' => ConfigInterface::VALUE_TYPE_STANDARD, 'label' => __('Standard')],
+            ['value' => ConfigInterface::VALUE_TYPE_STANDARD, 'label' => __('Bold-Hosted (Standard)')],
             ['value' => ConfigInterface::VALUE_TYPE_PARALLEL, 'label' => __('Dual')],
-            ['value' => ConfigInterface::VALUE_TYPE_SELF, 'label' => __('Self-Hosted (Adobe storefront)')],
-            ['value' => ConfigInterface::VALUE_TYPE_SELF_REACT, 'label' => __('Self-Hosted (Bold Templates)')],
+            ['value' => ConfigInterface::VALUE_TYPE_SELF, 'label' => __('Payment Booster')],
+            ['value' => ConfigInterface::VALUE_TYPE_SELF_REACT, 'label' => __('Self-Hosted')],
         ];
     }
 }

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -15,6 +15,7 @@ cp vendor/bold-commerce/module-checkout/patches/[file].patch m2-hotfixes
 
 ### List of available patches
 
-| File                   | Magento version | Description                                     |
-|------------------------|-----------------|-------------------------------------------------|
-| MAGETWO-70885_2.3.3-p1 | <= 2.3.3-p1     | Fix order increment ID changing on order update |
+| File                          | Magento version | Description                                     |
+|-------------------------------|-----------------|-------------------------------------------------|
+| MAGETWO-70885_2.3.3-p1        | <= 2.3.3-p1     | Fix order increment ID changing on order update |
+| MAGETWO-PAYMENT-BOOSTER_2.3.4 | <= 2.3.4        | Compatability fix for Payment Booster           |

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,10 +19,10 @@
                     <label>Bold Checkout Type</label>
                     <source_model>Bold\Checkout\Model\Config\Source\CheckoutTypeSource</source_model>
                     <comment><![CDATA[
-                        Standard — replace the native checkout with Bold Checkout's three-page checkout.<br>
+                        Bold-Hosted (Standard) — replace the native checkout with Bold Checkout's three-page checkout.<br>
                         Dual —  allow customers to choose between the native checkout or Bold Checkout.<br>
-                        Self-Hosted (Adobe storefront) — use the native checkout with Bold Checkout's payment options.<br>
-                        Self-Hosted (Bold Templates) — replace the native checkout with Bold Checkout's <a target='_blank' href="https://github.com/bold-commerce/checkout-experience-templates">Open Source Checkout Templates</a>.
+                        Payment Booster — use the native checkout with Bold Checkout's payment options.<br>
+                        Self-Hosted — replace the native checkout with Bold Checkout's <a target='_blank' href="https://github.com/bold-commerce/checkout-experience-templates">Open Source Checkout Templates</a>.
                     ]]></comment>
                 </field>
                 <field id="payment_title" translate="label" type="text" sortOrder="16" showInDefault="1" showInWebsite="1">

--- a/patches/MAGETWO-PAYMENT-BOOSTER_2.3.4.patch
+++ b/patches/MAGETWO-PAYMENT-BOOSTER_2.3.4.patch
@@ -1,0 +1,59 @@
+diff --git a/src/vendor/magento/module-sales-rule/view/frontend/web/js/action/select-payment-method-mixin.js b/src/vendor/magento/module-sales-rule/view/frontend/web/js/action/select-payment-method-mixin.js
+new file mode 100644
+--- /dev/null
++++ b/src/vendor/magento/module-sales-rule/view/frontend/web/js/action/select-payment-method-mixin.js
+@@ -0,0 +1,32 @@
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++define([
++    'jquery',
++    'mage/utils/wrapper',
++    'Magento_Checkout/js/model/quote',
++    'Magento_SalesRule/js/model/payment/discount-messages',
++    'Magento_Checkout/js/action/set-payment-information',
++    'Magento_Checkout/js/action/get-totals'
++], function ($, wrapper, quote, messageContainer, setPaymentInformationAction, getTotalsAction) {
++    'use strict';
++
++    return function (selectPaymentMethodAction) {
++
++        return wrapper.wrap(selectPaymentMethodAction, function (originalSelectPaymentMethodAction, paymentMethod) {
++
++            originalSelectPaymentMethodAction(paymentMethod);
++
++            $.when(
++                setPaymentInformationAction(
++                    messageContainer,
++                    {
++                        method: paymentMethod.method
++                    }
++                )
++            );
++        });
++    };
++
++});
+
+===================================================================
+
+diff --git a/src/vendor/magento/module-sales-rule/view/frontend/requirejs-config.js b/src/vendor/magento/module-sales-rule/view/frontend/requirejs-config.js
+new file mode 100644
+--- /dev/null
++++ b/src/vendor/magento/module-sales-rule/view/frontend/requirejs-config.js
+@@ -0,0 +1,14 @@
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++
++var config = {
++  config: {
++    mixins: {
++      'Magento_Checkout/js/action/select-payment-method': {
++        'Magento_SalesRule/js/action/select-payment-method-mixin': true
++      }
++    }
++  }
++};


### PR DESCRIPTION
This patch includes 2 additional files from Magento v2.3.5 which allows Payment Booster to work on Magento versions <=2.3.4. 

These files trigger the `set-payment-information` action when a payment method is selected which will set the customer's e-mail on the order and is needed for the Payment Booster frame to load. 

The code for these 2 files are pulled directly from Magento v2.3.5. 

Also included in this PR are some copy updates for the Bold Checkout options in the Magento admin. 