### PR TITLE
[INTER-3426] - Load Quote and Collect Totals Before Returning Set Shipping Method Response

### DIFF
--- a/Model/Quote/SetQuoteShippingMethod.php
+++ b/Model/Quote/SetQuoteShippingMethod.php
@@ -73,6 +73,9 @@ class SetQuoteShippingMethod implements SetQuoteShippingMethodInterface
             ->setShippingCarrierCode($shippingCarrierCode)
             ->setShippingMethodCode($shippingMethodCode);
         $this->shippingInformationManagement->saveAddressInformation($cartId, $shippingInformation);
+        // Load the quote again to get changes to shipping
+        $quote = $this->loadAndValidate->load($shopId, $cartId);
+        $quote->collectTotals();
         return $this->quoteResultBuilder->createSuccessResult($quote);
     }
 }


### PR DESCRIPTION
Load and validate the quote after setting the shipping line and collect totals so we return a complete and up to date quote to the platform connector. This will prevent having the platform connector to make an extra request to get the quote again right after setting shipping lines. Set Quote Shipping Method now returns an identical response after setting the method to what the get quote endpoint does.

Without this the response from setQuoteShippingMethod had a few issues:
1. Shipping Methods only had the selected method instead of all available methods
2. Item taxes were not present in the quote
3. Totals still had the previously selected shipping method amount

This change is to be done with [Platform Connector PR](https://github.com/bold-commerce/magento-2-platform-connector/pull/126)