### PR TITLE
Add cd to update platform sh stores loop

### DIFF
--- a/.github/workflows/deploy-all-psh-stores.yaml
+++ b/.github/workflows/deploy-all-psh-stores.yaml
@@ -35,4 +35,5 @@ jobs:
             platform project:get --no-interaction $PROJECT $PROJECT
             cd $PROJECT
             platform redeploy --no-wait
+            cd ..
           done


### PR DESCRIPTION
Deploying to psh stores loop kept concatenating the platform IDs causing nesting of the projects.
First store: (4zd46xwakdkxm)
`Cloning into '/home/runner/work/adobe-commerce-bold-checkout/adobe-commerce-bold-checkout/4zd46xwakdkxm'...`
Turns into: (ou3kp434ifvge)
`Cloning into '/home/runner/work/adobe-commerce-bold-checkout/adobe-commerce-bold-checkout/4zd46xwakdkxm/4e57skz5hn4xs/ofh5fl52rnr52/go2aunohlqo2g/qrwxolomviq66/uws6vt27pbeae/bo5h2mztlvd3u/x5kw4m2suovw6/wogofrxt5lzlm/7eo65bygpqlcw/4a4lezmdbiiga/5nx27kujfvbfu/5zd3b7qrpkrzg/n5harvyjmup4k/i4omqtgvsv7tu/ou3kp434ifvge'...`
