### PR TITLE
Move addition of SKU & vendor fields to hydration class

### DIFF
--- a/Model/Order/HydrateOrderFromQuote.php
+++ b/Model/Order/HydrateOrderFromQuote.php
@@ -85,9 +85,12 @@ class HydrateOrderFromQuote implements HydrateOrderFromQuoteInterface
             return $sum + $discountLine['value'];
         });
 
+        $cartItems = $this->getCartLineItems->getItems($quote);
+        $formattedCartItems = $this->formatCartLineItems($cartItems);
+
         $body = [
             'billing_address' => $this->addressConverter->convert($billingAddress),
-            'cart_items' => $this->getCartLineItems->getItems($quote),
+            'cart_items' => $formattedCartItems,
             'taxes' => $this->getTaxLines($totals['tax']['full_info']),
             'discounts' => $discounts,
             'fees' => $fees,
@@ -194,5 +197,19 @@ class HydrateOrderFromQuote implements HydrateOrderFromQuoteInterface
         }
 
         return [$fees, $discounts];
+    }
+
+    /**
+     * @param array $cartItems
+     * @return array
+     */
+    private function formatCartLineItems(array $cartItems): array
+    {
+        foreach ($cartItems as &$item) {
+            $item['sku'] = '';
+            $item['vendor'] = '';
+        }
+
+        return $cartItems;
     }
 }

--- a/Model/Quote/GetCartLineItems.php
+++ b/Model/Quote/GetCartLineItems.php
@@ -98,7 +98,6 @@ class GetCartLineItems
     {
         return [
             'id' => (int)$item->getProduct()->getId(),
-            'sku' => $item->getSku(),
             'quantity' => $this->extractLineItemQuantity($item),
             'title' => $this->getLineItemName($item),
             'product_title' => $this->getLineItemName($item),

--- a/Model/Quote/GetCartLineItems.php
+++ b/Model/Quote/GetCartLineItems.php
@@ -107,7 +107,6 @@ class GetCartLineItems
             'requires_shipping' => !$item->getProduct()->getIsVirtual(),
             'line_item_key' => (string)$item->getId(),
             'price' => $this->getLineItemPrice($item),
-            'vendor' => '',
         ];
     }
 


### PR DESCRIPTION
Moving the addition of the `sku` and `vendor` fields to be handled inside of the `HydrateOrderFromQuote` class.

When these fields (specifically `sku`) are added in Model/Quote/GetCartLineItems.php it breaks non-simple-order init functionality. 