### PR TITLE
Add customer name to quote for guest orders

### DIFF
--- a/Model/Order/PlaceOrder/CreateOrderFromQuote.php
+++ b/Model/Order/PlaceOrder/CreateOrderFromQuote.php
@@ -156,6 +156,11 @@ class CreateOrderFromQuote
     private function prepareCartForCustomer(CartInterface $cart): void
     {
         if (!$cart->getCustomerId()) {
+            $cart->setCustomerPrefix($cart->getBillingAddress()->getPrefix());
+            $cart->setCustomerFirstname($cart->getBillingAddress()->getFirstname());
+            $cart->setCustomerMiddlename($cart->getBillingAddress()->getMiddlename());
+            $cart->setCustomerLastname($cart->getBillingAddress()->getLastname());
+            $cart->setCustomerSuffix($cart->getBillingAddress()->getSuffix());
             $cart->setCustomerEmail($cart->getBillingAddress()->getEmail());
             $cart->setCustomerIsGuest(true);
             $cart->setCustomerGroupId(GroupManagement::NOT_LOGGED_IN_ID);


### PR DESCRIPTION
- Fixes customer name showing as "Guest" on orders caused by customer name fields being set to `NULL` in database.

Before:

<img width="1385" alt="Screenshot 2024-06-07 at 15 11 00" src="https://github.com/bold-commerce/adobe-commerce-bold-checkout/assets/3091468/ddc7eb89-0b5a-4389-adfb-c557092319d4">

After:

<img width="1385" alt="Screenshot 2024-06-07 at 15 05 17" src="https://github.com/bold-commerce/adobe-commerce-bold-checkout/assets/3091468/fd856b06-5053-4411-93bd-89e93d54b808">
