### PR TITLE
Add fast checkout refresh

### DIFF
--- a/Model/Order/ResumeOrder.php
+++ b/Model/Order/ResumeOrder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Bold\Checkout\Model\Order;
 
 use Bold\Checkout\Api\Http\ClientInterface;
-use Bold\CheckoutMeta\Model\Config;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\Data\CartInterface;
@@ -23,19 +22,10 @@ class ResumeOrder
     private $client;
 
     /**
-     * @var Config
-     */
-    private $checkoutMetaConfig;
-
-    /**
      * @param ClientInterface $client
      */
-    public function __construct(
-        ClientInterface $client,
-        Config $checkoutMetaConfig
-    ) {
+    public function __construct(ClientInterface $client) {
         $this->client = $client;
-        $this->checkoutMetaConfig = $checkoutMetaConfig;
     }
 
     /**
@@ -54,12 +44,30 @@ class ResumeOrder
             'public_order_id' => $publicOrderId
         ];
 
-        $useFastCheckout = $this->checkoutMetaConfig->getUseFastCheckout($websiteId);
-        $simpleResumeUrl = sprintf(self::RESUME_SIMPLE_URL, $publicOrderId);
+        $orderData = $this->client->post($websiteId, self::RESUME_URL, $body)->getBody();
 
-        $orderData = $useFastCheckout
-            ? $this->client->post($websiteId, $simpleResumeUrl, [])->getBody()
-            : $this->client->post($websiteId, self::RESUME_URL, $body)->getBody();
+        $publicOrderId = $orderData['data']['public_order_id'] ?? null;
+        if (!$publicOrderId) {
+            throw new LocalizedException(__('Cannot resume order'));
+        }
+
+        return $orderData;
+    }
+
+    /**
+     * Resume a simple order on Bold's side to get a refreshed JWT.
+     *
+     * @param CartInterface $quote
+     * @param string $publicOrderId
+     * @return array
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function resumeSimpleOrder(CartInterface $quote, string $publicOrderId): array
+    {
+        $websiteId = (int)$quote->getStore()->getWebsiteId();
+        $simpleResumeUrl = sprintf(self::RESUME_SIMPLE_URL, $publicOrderId);
+        $orderData = $this->client->post($websiteId, $simpleResumeUrl, [])->getBody();
 
         $publicOrderId = $orderData['data']['public_order_id'] ?? null;
         if (!$publicOrderId) {


### PR DESCRIPTION
Adds a check to see if a store is using fast checkout or not and based on that setting call the appropriate refresh endpoint.