### PR TITLE
Make New API Endpoints Compatible with PHP 7.2

### DIFF
--- a/Model/Order/HydrateOrderFromQuote.php
+++ b/Model/Order/HydrateOrderFromQuote.php
@@ -63,7 +63,7 @@ class HydrateOrderFromQuote implements HydrateOrderFromQuoteInterface
         GetCartLineItems $getCartLineItems,
         Converter $addressConverter,
         ToOrderAddress $quoteToOrderAddressConverter,
-        ProductFactory $productFactory,
+        ProductFactory $productFactory
     ) {
         $this->client = $client;
         $this->getCartLineItems = $getCartLineItems;
@@ -142,7 +142,7 @@ class HydrateOrderFromQuote implements HydrateOrderFromQuoteInterface
      * @param float|string $dollars
      * @return integer
      */
-    private function convertToCents(float|string $dollars): int
+    private function convertToCents($dollars): int
     {
         return (int)round(floatval($dollars) * 100);
     }

--- a/Model/Order/PlaceOrder.php
+++ b/Model/Order/PlaceOrder.php
@@ -84,13 +84,41 @@ class PlaceOrder implements PlaceOrderInterface
      * @var LoadAndValidate
      */
     private $loadAndValidate;
-    private MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId;
-    private StoreManagerInterface $storeManager;
-    private ClientInterface $client;
-    private OrderDataInterfaceFactory $orderDataFactory;
-    private OrderPaymentInterfaceFactory $paymentFactory;
-    private TransactionInterfaceFactory $transactionFactory;
-    private CheckoutSession $checkoutSession;
+
+    /**
+     * @var \Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface
+     */
+    private $maskedQuoteIdToQuoteId;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var \Bold\Checkout\Api\Http\ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var \Bold\Checkout\Api\Data\PlaceOrder\Request\OrderDataInterfaceFactory
+     */
+    private $orderDataFactory;
+
+    /**
+     * @var \Magento\Sales\Api\Data\OrderPaymentInterfaceFactory
+     */
+    private $paymentFactory;
+
+    /**
+     * @var \Magento\Sales\Api\Data\TransactionInterfaceFactory
+     */
+    private $transactionFactory;
+
+    /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
 
     /**
      * @param OrderPayloadValidator $orderPayloadValidator
@@ -191,7 +219,7 @@ class PlaceOrder implements PlaceOrderInterface
 
         try {
             $quoteId = $this->maskedQuoteIdToQuoteId->execute($quoteMaskId);
-        } catch (NoSuchEntityException) {
+        } catch (NoSuchEntityException $exception) {
             return $this->getValidationErrorResponse((string)__('Invalid quote mask ID "%1"', $quoteMaskId));
         }
 
@@ -309,7 +337,9 @@ class PlaceOrder implements PlaceOrderInterface
              *     gateway_response_data: string[]
              * } $transaction
              */
-            static fn (array $transaction): bool => $transaction['status'] !== 'failed'
+            static function (array $transaction): bool {
+                return $transaction['status'] !== 'failed';
+            }
         );
 
         if (count($transactions) === 0) {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "psr/log": "*"
   },
   "require-dev": {
-    "dms/phpunit-arraysubset-asserts": "^0.5.0"
+    "dms/phpunit-arraysubset-asserts": "^0.5.0",
+    "rector/rector": "^1.1"
   },
   "suggest": {
     "magento/module-inventory-sales-api": "type: magento2-module, name: Magento_InventorySalesApi, version: *"

--- a/rector.php
+++ b/rector.php
@@ -7,7 +7,7 @@ use Rector\Set\ValueObject\DowngradeLevelSetList;
 
 return RectorConfig::configure()
     ->withPaths([
-        __DIR__ . '/app',
+        __DIR__,
     ])
     ->withSets([
         DowngradeLevelSetList::DOWN_TO_PHP_72

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/app',
+    ])
+    ->withSets([
+        DowngradeLevelSetList::DOWN_TO_PHP_72
+    ]);


### PR DESCRIPTION
- [Make Hydrate Order API compatible with PHP 7.2](https://github.com/bold-commerce/adobe-commerce-bold-checkout/commit/3afb227e2768851f0b18c8e72c57701bf42d6ec8)
- [Make Auth and Place Order API PHP 7.2 compatible](https://github.com/bold-commerce/adobe-commerce-bold-checkout/commit/77147b3a03e7449f63a03106af07abaed1f667ab)