### PR TITLE
Fix save when setting up local dev

### DIFF
--- a/Model/Http/BoldClient.php
+++ b/Model/Http/BoldClient.php
@@ -167,14 +167,14 @@ class BoldClient implements ClientInterface
             $host = $parseApiUrl['host'];
             $path = $parseApiUrl['path'];
             $tunnelDomain = ltrim($path, '/');
-            $baseApiUrl = $scheme.'://'.$host;
+            $baseApiUrl = $scheme.'://'.$host.'/';
 
             if ($url === 'shops/v1/info') {
                 $apiUrl = $baseApiUrl;
             }
 
             if (str_contains($url, 'checkout_sidekick')) {
-                $apiUrl = $baseApiUrl.'/sidekick-'.$tunnelDomain;
+                $apiUrl = $baseApiUrl.'sidekick-'.$tunnelDomain;
             }
         }
 


### PR DESCRIPTION
Extension was failing to save while trying to reach out to account center 'shops/v1/info' when the setup was using local environment with bold.ninja tunnel.

It was happening because it missed the trailling '/' on the base url before concatnating with 'shops/v1/info', by adding it fixed the issue.