### PR TITLE
Fix hydrate endpoint for swagger

### DIFF
--- a/Api/Order/HydrateOrderFromQuoteInterface.php
+++ b/Api/Order/HydrateOrderFromQuoteInterface.php
@@ -2,7 +2,6 @@
 
 namespace Bold\Checkout\Api\Order;
 
-use Bold\Checkout\Api\Data\Http\Client\ResultInterface;
 use Magento\Quote\Api\Data\CartInterface;
 
 /**
@@ -13,9 +12,9 @@ interface HydrateOrderFromQuoteInterface
     /**
      * Hydrate Bold simple order with Magento quote data
      *
-     * @param CartInterface $quote
+     * @param \Magento\Quote\Api\Data\CartInterface $quote
      * @param string $publicOrderId
-     * @return \Bold\Checkout\Api\Data\Http\Client\ResultInterface
+     * @return void
      */
-    public function hydrate(CartInterface $quote, string $publicOrderId): ResultInterface;
+    public function hydrate(CartInterface $quote, string $publicOrderId): void;
 }


### PR DESCRIPTION
The way the hydrate endpoint was setup was breaking swagger. These changes fix this issue.

The endpoint return type is changed to `void` and a `LocalizedException` is thrown if the hydrate call to side-kick fails. 

Before
This page would not load properly and show an error

After
This page will load and will display the API schema