### PR TITLE
Add API Endpoint for Authorizing and Placing Customer Orders

### DIFF
--- a/Model/Order/PlaceOrder.php
+++ b/Model/Order/PlaceOrder.php
@@ -247,10 +247,14 @@ class PlaceOrder implements PlaceOrderInterface
         $websiteId = (int)$this->storeManager->getStore()->getWebsiteId();
         $shopId = $this->config->getShopId($websiteId) ?? '';
 
-        try {
-            $quoteId = $this->maskedQuoteIdToQuoteId->execute($quoteMaskId);
-        } catch (NoSuchEntityException $exception) {
-            return $this->getValidationErrorResponse((string)__('Invalid quote mask ID "%1"', $quoteMaskId));
+        if (!is_numeric($quoteMaskId) && strlen($quoteMaskId) === 32) {
+            try {
+                $quoteId = $this->maskedQuoteIdToQuoteId->execute($quoteMaskId);
+            } catch (NoSuchEntityException $exception) {
+                return $this->getValidationErrorResponse((string)__('Invalid quote mask ID "%1"', $quoteMaskId));
+            }
+        } else {
+            $quoteId = $quoteMaskId;
         }
 
         try {

--- a/Test/Integration/Model/Order/PlaceOrderTest.php
+++ b/Test/Integration/Model/Order/PlaceOrderTest.php
@@ -32,9 +32,10 @@ final class PlaceOrderTest extends TestCase // phpcs:ignore Magento2.PHP.FinalIm
     private CartInterface $quote;
 
     /**
+     * @dataProvider authorizesAndPlacesOrderSuccessfullyDataProvider
      * @magentoDataFixture Magento/Checkout/_files/quote_with_shipping_method.php
      */
-    public function testAuthorizesAndPlacesOrderSuccessfully(): void
+    public function testAuthorizesAndPlacesOrderSuccessfully(bool $useQuoteMaskId): void
     {
         $configMock = $this->createMock(ConfigInterface::class);
         $loadAndValidateMock = $this->createMock(LoadAndValidate::class);
@@ -48,13 +49,14 @@ final class PlaceOrderTest extends TestCase // phpcs:ignore Magento2.PHP.FinalIm
                 'client' => $boldCheckoutApiClientMock,
             ]
         );
+        $quote = $this->getQuote();
         $boldCheckoutApiResultMock = $this->createMock(ResultInterface::class);
 
         $configMock->method('getShopId')
             ->willReturn('74e51be84d1643e8a89df356b80bf2b5');
 
         $loadAndValidateMock->method('load')
-            ->willReturn($this->getQuote());
+            ->willReturn($quote);
 
         $boldCheckoutApiClientMock->method('post')
             ->willReturn($boldCheckoutApiResultMock);
@@ -90,7 +92,7 @@ final class PlaceOrderTest extends TestCase // phpcs:ignore Magento2.PHP.FinalIm
         /** @var PlaceOrderResultInterface $response */
         $response = $placeOrderService->authorizeAndPlace(
             'd407dc80-3470-49a4-9969-7a12cf17fd4a',
-            $this->getQuoteMaskId()
+            $useQuoteMaskId ? $this->getQuoteMaskId() : $quote->getId()
         );
 
         /** @var OrderInterface|null $order */
@@ -251,6 +253,21 @@ final class PlaceOrderTest extends TestCase // phpcs:ignore Magento2.PHP.FinalIm
 
         self::assertEquals($expectedErrorData, $actualErrorData);
         self::assertNull($response->getOrder());
+    }
+
+    /**
+     * @return array<string, array<string, boolean>>
+     */
+    public function authorizesAndPlacesOrderSuccessfullyDataProvider(): array
+    {
+        return [
+            'with quote mask id' => [
+                'useQuoteMaskId' => true,
+            ],
+            'with quote id' => [
+                'useQuoteMaskId' => false,
+            ],
+        ];
     }
 
     public function boldAuthorizedPaymentsApiResultDataProvider(): array

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -153,4 +153,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
+        <arguments>
+            <argument name="paramOverriders" xsi:type="array">
+                <item name="%quote_mask_id%" xsi:type="object">Magento\Quote\Model\Webapi\ParamOverriderCartId\Proxy</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -48,6 +48,15 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <route method="POST" url="/V1/orders/:publicOrderId/quote/mine/authorizeAndPlace">
+        <service class="Bold\Checkout\Api\PlaceOrderInterface" method="authorizeAndPlace"/>
+        <resources>
+            <resource ref="self"/>
+        </resources>
+        <data>
+            <parameter name="quoteMaskId" force="true">%quote_mask_id%</parameter>
+        </data>
+    </route>
     <route method="PUT" url="/V1/shops/:shopId/payments">
         <service class="Bold\Checkout\Api\Order\UpdatePaymentInterface" method="update"/>
         <resources>


### PR DESCRIPTION
Allows quotes for logged in customers to authorized and placed by calling the `/V1/orders/:publicOrderId/quote/mine/authorizeAndPlace` API endpoint.