### PR TITLE
Fix changing str_contains to strpos to work on PHP 7.2

### DIFF
--- a/Model/Http/BoldClient.php
+++ b/Model/Http/BoldClient.php
@@ -161,7 +161,7 @@ class BoldClient implements ClientInterface
     {
         $apiUrl = $this->config->getApiUrl($websiteId);
 
-        if (str_contains($apiUrl, 'bold.ninja')) {
+        if (strpos($apiUrl, 'bold.ninja') !== false) {
             $parseApiUrl = parse_url($apiUrl);
             $scheme = $parseApiUrl['scheme'];
             $host = $parseApiUrl['host'];
@@ -173,7 +173,7 @@ class BoldClient implements ClientInterface
                 $apiUrl = $baseApiUrl;
             }
 
-            if (str_contains($url, 'checkout_sidekick')) {
+            if (strpos($url, 'checkout_sidekick') !== false) {
                 $apiUrl = $baseApiUrl.'sidekick-'.$tunnelDomain;
             }
         }


### PR DESCRIPTION
Changing `str_contains` to `strpos` to work on PHP 7.2

```
www-data@magento-open-source-php-fpm:/var/www/html$ vendor/bin/rector process -n -c app/code/Bold/Checkout/rector.php
 118/118 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) app/code/Bold/Checkout/Model/Http/BoldClient.php:160

    ---------- begin diff ----------
@@ @@
     {
         $apiUrl = $this->config->getApiUrl($websiteId);

-        if (str_contains($apiUrl, 'bold.ninja')) {
+        if (strpos($apiUrl, 'bold.ninja') !== false) {
             $parseApiUrl = parse_url($apiUrl);
             $scheme = $parseApiUrl['scheme'];
             $host = $parseApiUrl['host'];
@@ @@
                 $apiUrl = $baseApiUrl;
             }

-            if (str_contains($url, 'checkout_sidekick')) {
+            if (strpos($url, 'checkout_sidekick') !== false) {
                 $apiUrl = $baseApiUrl.'sidekick-'.$tunnelDomain;
             }
         }
    ----------- end diff -----------

Applied rules:
 * DowngradeStrContainsRector (https://wiki.php.net/rfc/str_contains)



 [OK] 1 file would have changed (dry-run) by Rector
```