### PR TITLE
Remove trailing comma

### DIFF
--- a/Model/Order/GetOrderPublicId.php
+++ b/Model/Order/GetOrderPublicId.php
@@ -30,7 +30,7 @@ class GetOrderPublicId
      */
     public function __construct(
         OrderExtensionDataFactory  $orderExtensionDataFactory,
-        OrderExtensionDataResource $orderExtensionDataResource,
+        OrderExtensionDataResource $orderExtensionDataResource
     ) {
         $this->orderExtensionDataFactory = $orderExtensionDataFactory;
         $this->orderExtensionDataResource = $orderExtensionDataResource;


### PR DESCRIPTION
Trailing comma is breaking for older versions of php