### PR TITLE
Only execute complete order for simple orders

### DIFF
--- a/Model/Order/CompleteOrderPool.php
+++ b/Model/Order/CompleteOrderPool.php
@@ -15,7 +15,7 @@ use Psr\Log\LoggerInterface;
  */
 class CompleteOrderPool implements CompleteOrderInterface
 {
-    public const API_TYPE_SIMPLE = 'simple';
+    private const API_TYPE_DEFAULT = 'default';
 
     /**
      * @var QuoteExtensionDataFactory
@@ -72,7 +72,7 @@ class CompleteOrderPool implements CompleteOrderInterface
         // TODO: Remove logic around order pool as we only need to run logic here for simple order types
         // For 'default' order types all order complete processing happens in the platform connector
         // TODO: Update naming around simple/non-simple orders to signal it relates to source of truth instead of order type
-        if ($flowType === self::API_TYPE_SIMPLE) {
+        if ($flowType !== self::API_TYPE_DEFAULT) {
             $processor = $this->pool[$flowType] ?? null;
             if (!($processor instanceof CompleteOrderInterface)) {
                 $this->logger->error(

--- a/Model/Order/CompleteOrderPool.php
+++ b/Model/Order/CompleteOrderPool.php
@@ -15,7 +15,6 @@ use Psr\Log\LoggerInterface;
  */
 class CompleteOrderPool implements CompleteOrderInterface
 {
-    private const API_TYPE_DEFAULT = 'default';
 
     /**
      * @var QuoteExtensionDataFactory
@@ -72,7 +71,7 @@ class CompleteOrderPool implements CompleteOrderInterface
         // TODO: Remove logic around order pool as we only need to run logic here for simple order types
         // For 'default' order types all order complete processing happens in the platform connector
         // TODO: Update naming around simple/non-simple orders to signal it relates to source of truth instead of order type
-        if ($flowType !== self::API_TYPE_DEFAULT) {
+        if ($flowType !== InitOrderFromQuote::API_TYPE_DEFAULT) {
             $processor = $this->pool[$flowType] ?? null;
             if (!($processor instanceof CompleteOrderInterface)) {
                 $this->logger->error(


### PR DESCRIPTION
For `default` order types both the module and checkout were attempting to perform the complete order calls. This was putting the order into a locked state and was resulting in orders not being created in Magpie and therefore payment details were unable to be updated on the platform after checkout captured payments. 

This removes the complete order call from `default` orders and only executes this piece for `simple` orders. 