### PR TITLE
META-334: Fix duplicate bold checkout orders

### DIFF
--- a/Model/Order/PlaceOrder/CreateOrderFromPayload.php
+++ b/Model/Order/PlaceOrder/CreateOrderFromPayload.php
@@ -117,16 +117,19 @@ class CreateOrderFromPayload
         );
         $this->addCommentsToOrder->addComments($magentoOrder, $orderPayload);
         $orderExtensionData = $this->orderExtensionDataFactory->create();
-        $orderExtensionData->setPublicId($orderPayload->getPublicId());
-        $orderExtensionData->setOrderId((int)$magentoOrder->getId());
-        $this->eventManager->dispatch(
-            'create_order_from_payload_extension_data_save_before',
-            [
-                'orderPayload' => $orderPayload,
-                'orderExtensionData' => $orderExtensionData,
-            ]
-        );
-        $this->orderExtensionDataResource->save($orderExtensionData);
+        $this->orderExtensionDataResource->load($orderExtensionData, (int)$magentoOrder->getId(), 'order_id');
+        if (!$orderExtensionData->getPublicId()) {
+            $orderExtensionData->setPublicId($orderPayload->getPublicId());
+            $orderExtensionData->setOrderId((int)$magentoOrder->getId());
+            $this->eventManager->dispatch(
+                'create_order_from_payload_extension_data_save_before',
+                [
+                    'orderPayload' => $orderPayload,
+                    'orderExtensionData' => $orderExtensionData,
+                ]
+            );
+            $this->orderExtensionDataResource->save($orderExtensionData);
+        }
 
         return $magentoOrder;
     }


### PR DESCRIPTION
Issue: 
- The `bold_checkout_order` is currently saved twice in the db, first in the `CheckoutSubmitAllAfterObserver`, and then again the at the place order endpoint

Fix:
- Add a check at the place order endpoint and only save to the `bold_checkout_order` if the mangeto order with the bold public id does not exist in the db 