### PR TITLE
Initial attempt at improving performance

### DIFF
--- a/Model/Order/PlaceOrder.php
+++ b/Model/Order/PlaceOrder.php
@@ -396,13 +396,13 @@ class PlaceOrder implements PlaceOrderInterface
         return $response;
     }
 
-    private function getFirstTransAction(array $transactions): array
+    private function getFirstTransaction(array $transactions): array
     {
         $firstTransaction = $transactions['data']['transactions'][0] ?? null;
-        if($firstTransaction === null) {
+        if ($firstTransaction === null) {
             throw new LocalizedException(__('No transactions found'));
         }
-        if($firstTransaction['status'] === 'failed') {
+        if ($firstTransaction['status'] === 'failed') {
             throw new LocalizedException(__('First transaction failed'));
         }
         return $firstTransaction;

--- a/Model/Order/PlaceOrder.php
+++ b/Model/Order/PlaceOrder.php
@@ -278,9 +278,6 @@ class PlaceOrder implements PlaceOrderInterface
             return $this->getValidationErrorResponse($e->getMessage());
         }
 
-        if ($quote->getId() === null) {
-            return $this->getValidationErrorResponse((string)__('Could not find quote with ID "%1"', $quoteId));
-        }
         $endValidateTime = microtime(true);
         $this->logger->info('Time to validate: ' . ($endValidateTime - $startValidateTime));
 

--- a/Model/Order/PlaceOrder.php
+++ b/Model/Order/PlaceOrder.php
@@ -427,9 +427,9 @@ class PlaceOrder implements PlaceOrderInterface
         if (isset($response['errors']) && !empty($response['errors'])) {
             $error = $response['errors'][0];
             $errorMessage = isset($error['message']) ? $error['message'] : 'Unknown error occurred';
-            throw new LocalizedException($errorMessage);
+            throw new LocalizedException(__($errorMessage));
         } else if (!isset($response['data']) || $response['data'] === null) {
-            throw new LocalizedException('No data found');
+            throw new LocalizedException(__('No data found'));
         }
 
         return $response;
@@ -439,10 +439,10 @@ class PlaceOrder implements PlaceOrderInterface
     {
         $firstTransaction = $transactions['data']['transactions'][0] ?? null;
         if($firstTransaction === null) {
-            throw new LocalizedException('No transactions found');
+            throw new LocalizedException(__('No transactions found'));
         }
         if($firstTransaction['status'] === 'failed') {
-            throw new LocalizedException('First transaction failed');
+            throw new LocalizedException(__('First transaction failed'));
         }
         return $firstTransaction;
     }


### PR DESCRIPTION
Performance improvements and refactoring for the authorization end-point. These are micro-improvements overall. 

1. Remove try / catch and handle error handling differently
2. Switch out `explode` to `substr` 
3. Switch out `array_shift` to grabbing by index. 

**Testing**
1. Tested success case ✅ 
2. Tested transaction error case -> This can be done using totals at $2000 or $3000 as per braintree docs. ✅ 
3. Tested performance locally and this is harder to quantify since local rates are varying, and the biggest bottle neck is the API call time, but testing things around it this is consistently coming up slightly faster. 