### PR TITLE
CHK-3417: Move Type Declaration for PlaceOrder Service from Web API Scope to Global Scope

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -184,4 +184,10 @@
             </argument>
         </arguments>
     </type>
+    <type name="Bold\Checkout\Model\Order\PlaceOrder">
+        <arguments>
+            <argument name="client" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -11,10 +11,4 @@
             <argument name="requiredProperties" xsi:type="const">\Bold\Checkout\Api\Data\PlaceOrder\Request\OrderDataInterface::PROPERTIES_REQUIRED</argument>
         </arguments>
     </type>
-    <type name="Bold\Checkout\Model\Order\PlaceOrder">
-        <arguments>
-            <argument name="client" xsi:type="object">Bold\Checkout\Model\Http\BoldClient</argument>
-            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
-        </arguments>
-    </type>
 </config>


### PR DESCRIPTION
Fixes CHK-3417

Fixes "Cannot instantiate interface" error thrown while running the Asynchronous Bulk API message queue consumer.