### PR TITLE
feat: using existing bold order instead of always creating a new one [CSE-28]

### DIFF
--- a/Api/BoldQuoteRepositoryInterface.php
+++ b/Api/BoldQuoteRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types = 1);
+
+//phpcs:disable Magento2.Annotation.MethodArguments.NoCommentBlock
+//phpcs:disable Magento2.Annotation.MethodArguments.ParamMissing
+//phpcs:disable Magento2.Annotation.MethodAnnotationStructure.MethodAnnotation
+
+namespace Bold\Checkout\Api;
+
+use Bold\Checkout\Api\Data\BoldQuoteInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+interface BoldQuoteRepositoryInterface
+{
+    /**
+     * @param int $cartId
+     * @return BoldQuoteInterface
+     * @throws NoSuchEntityException
+     */
+    public function getByCartId(int $cartId): BoldQuoteInterface;
+}

--- a/Api/Data/BoldQuoteInterface.php
+++ b/Api/Data/BoldQuoteInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+//phpcs:disable Magento2.Annotation.MethodArguments.NoCommentBlock
+//phpcs:disable Magento2.Annotation.MethodArguments.ParamMissing
+//phpcs:disable Magento2.Annotation.MethodAnnotationStructure.MethodAnnotation
+
+namespace Bold\Checkout\Api\Data;
+
+interface BoldQuoteInterface
+{
+    public function getId();
+
+    public function getQuoteId(): ?int;
+
+    public function setQuoteId(int $quoteId): void;
+
+    public function getOrderCreated(): ?bool;
+
+    public function setOrderCreated(bool $orderCreated): void;
+
+    public function getApiType(): ?string;
+
+    public function setApiType(string $apiType): void;
+
+    public function getPublicOrderId(): ?string;
+
+    public function setPublicOrderId(string $publicOrderId): void;
+}

--- a/Model/BoldQuoteRepository.php
+++ b/Model/BoldQuoteRepository.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types = 1);
+
+//phpcs:disable Magento2.Annotation.MethodArguments.NoCommentBlock
+//phpcs:disable Magento2.Annotation.MethodArguments.ParamMissing
+//phpcs:disable Magento2.Annotation.MethodAnnotationStructure.MethodAnnotation
+
+namespace Bold\Checkout\Model;
+
+use Bold\Checkout\Api\BoldQuoteRepositoryInterface;
+use Bold\Checkout\Api\Data\BoldQuoteInterface;
+use Bold\Checkout\Model\ResourceModel\Quote\QuoteExtensionData as QuoteExtensionDataResource;
+use Bold\Checkout\Model\Quote\QuoteExtensionDataFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class BoldQuoteRepository implements BoldQuoteRepositoryInterface
+{
+    /**
+     * @var QuoteExtensionDataResource
+     */
+    private $boldQuoteResource;
+
+    /**
+     * @var QuoteExtensionDataFactory
+     */
+    private $quoteExtensionDataFactory;
+
+    public function __construct(
+        QuoteExtensionDataResource $boldQuoteResource,
+        QuoteExtensionDataFactory $quoteExtensionDataFactory,
+    ) {
+        $this->boldQuoteResource = $boldQuoteResource;
+        $this->quoteExtensionDataFactory = $quoteExtensionDataFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getByCartId(int $cartId): BoldQuoteInterface
+    {
+        $boldQuote = $this->quoteExtensionDataFactory->create();
+        $this->boldQuoteResource->load($boldQuote, $cartId, QuoteExtensionDataResource::QUOTE_ID);
+        if ($boldQuote->getId() === null) {
+            throw new NoSuchEntityException(__('No Bold Quote found for ID: %1.', $cartId));
+        }
+
+        return $boldQuote;
+    }
+}

--- a/Model/Order/InitOrderFromQuote.php
+++ b/Model/Order/InitOrderFromQuote.php
@@ -139,6 +139,7 @@ class InitOrderFromQuote
             [
                 QuoteExtensionData::ORDER_CREATED => false,
                 QuoteExtensionData::API_TYPE => InitOrderFromQuote::API_TYPE_DEFAULT,
+                QuoteExtensionData::PUBLIC_ORDER_ID => $publicOrderId,
             ]
         );
 

--- a/Model/Quote/QuoteExtensionData.php
+++ b/Model/Quote/QuoteExtensionData.php
@@ -3,13 +3,14 @@ declare(strict_types=1);
 
 namespace Bold\Checkout\Model\Quote;
 
+use Bold\Checkout\Api\Data\BoldQuoteInterface;
 use Bold\Checkout\Model\ResourceModel\Quote\QuoteExtensionData as QuoteExtensionDataResource;
 use Magento\Framework\Model\AbstractModel;
 
 /**
  * Bold quote data entity.
  */
-class QuoteExtensionData extends AbstractModel
+class QuoteExtensionData extends AbstractModel implements BoldQuoteInterface
 {
     /**
      * @inheritDoc
@@ -71,5 +72,20 @@ class QuoteExtensionData extends AbstractModel
     public function getApiType(): ?string
     {
         return $this->getData(QuoteExtensionDataResource::API_TYPE);
+    }
+
+    public function setApiType(string $apiType): void
+    {
+        $this->setData(QuoteExtensionDataResource::API_TYPE, $apiType);
+    }
+
+    public function getPublicOrderId(): ?string
+    {
+        return $this->getData(QuoteExtensionDataResource::PUBLIC_ORDER_ID);
+    }
+
+    public function setPublicOrderId(string $publicOrderId): void
+    {
+        $this->setData(QuoteExtensionDataResource::PUBLIC_ORDER_ID, $publicOrderId);
     }
 }

--- a/Model/ResourceModel/Quote/QuoteExtensionData.php
+++ b/Model/ResourceModel/Quote/QuoteExtensionData.php
@@ -13,6 +13,7 @@ class QuoteExtensionData extends AbstractDb
     public const TABLE = 'bold_checkout_quote';
     public const ID = 'id';
     public const QUOTE_ID = 'quote_id';
+    public const PUBLIC_ORDER_ID = 'public_order_id';
     public const ORDER_CREATED = 'order_created';
     public const API_TYPE = 'api_type';
 

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -25,6 +25,7 @@
     <table name="bold_checkout_quote" resource="default" engine="innodb" comment="Bold Checkout Quote Additional Data">
         <column xsi:type="int" name="id" unsigned="true" nullable="false" identity="true" comment="ID"/>
         <column xsi:type="int" name="quote_id" unsigned="true" nullable="false" identity="false" comment="Magento Quote ID"/>
+        <column xsi:type="varchar" name="public_order_id" nullable="true" length="255" comment="Bold Order Public ID"/>
         <column xsi:type="smallint" name="order_created" default="0" comment="Magento Order Should Be Created On Magento Side"/>
         <column xsi:type="varchar" name="api_type" nullable="true" length="15" comment="Bold Checkout API Type"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -31,11 +31,12 @@
     "column": {
       "id": true,
       "quote_id": true,
+      "public_order_id": true,
       "order_created": true,
       "api_type": true
     },
     "constraint": {
-      "PRIMARY": true, 
+      "PRIMARY": true,
       "BOLD_CHECKOUT_QUOTE_QUOTE_ID": true
     }
   }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -33,6 +33,9 @@
     <preference for="Bold\Checkout\Api\Data\ModuleVersion\ResultInterface" type="Bold\Checkout\Model\Data\ModuleVersion\Result"/>
     <preference for="Bold\Checkout\Api\Data\ModuleVersion\ModuleVersionInterface" type="Bold\Checkout\Model\Data\ModuleVersion\ModuleVersion"/>
     <preference for="Bold\Checkout\Model\Order\CompleteOrderInterface" type="Bold\Checkout\Model\Order\CompleteOrderPool"/>
+    <preference for="Bold\Checkout\Api\Data\BoldQuoteInterface" type="Bold\Checkout\Model\Quote\QuoteExtensionData"/>
+    <preference for="Bold\Checkout\Api\BoldQuoteRepositoryInterface" type="Bold\Checkout\Model\BoldQuoteRepository"/>
+
     <type name="Bold\Checkout\Model\Order\CompleteOrderPool">
         <arguments>
             <argument name="pool" xsi:type="array">


### PR DESCRIPTION
Every time a customer goes to the checkout, a new cart/order is init on Bold Checkout, leaving the database with a lot of unused orders (on Checkout). A new check was added to resume an existing order.