### PR TITLE
[CHK-4851] skip opencart projects

### DIFF
--- a/.github/workflows/deploy-all-psh-stores.yaml
+++ b/.github/workflows/deploy-all-psh-stores.yaml
@@ -31,8 +31,14 @@ jobs:
           PROJECTS=`platform project:list --pipe`
           for PROJECT in $PROJECTS;
           do
-            echo "Updating project $PROJECT"
             platform project:get --no-interaction $PROJECT $PROJECT
+            PLATFORM_TYPE=`platform vget platform:type -p $PROJECT -e main --property value 2>/dev/null`
+            if [[ $PLATFORM_TYPE = opencart ]]; then
+              echo "Skipping opencart project $PROJECT"
+              continue
+            else
+              echo "Updating project $PROJECT"
+            fi
             cd $PROJECT
             date > timestamp
             git add timestamp


### PR DESCRIPTION
Adding a platform type variable to opencart stores, if a store has this variable it will skip updating with this workflow. This should have no impact on magento psh stores.