### PR TITLE
[CHK-4851] Get Platform SH Variables From List Instead of Get

### DIFF
--- a/.github/workflows/deploy-all-psh-stores.yaml
+++ b/.github/workflows/deploy-all-psh-stores.yaml
@@ -33,8 +33,14 @@ jobs:
           PROJECTS=`platform project:list --pipe`
           for PROJECT in $PROJECTS;
           do
-            echo "Updating project $PROJECT"
             platform project:get --no-interaction $PROJECT $PROJECT
+            PLATFORM_TYPE=`platform variable:list -p $PROJECT -e main --format plain | awk '/platform:type/ { print $3 }'`
+            if [[ $PLATFORM_TYPE = opencart ]]; then
+              echo "Skipping opencart project $PROJECT"
+              continue
+            else
+              echo "Updating project $PROJECT"
+            fi
             cd $PROJECT
             date > timestamp
             git add timestamp


### PR DESCRIPTION
Changed `platform variable:get {name}` to `platform variable:list` as searching for variable with `get` would exit the script when not found, which is to be expected on most projects. Now with variable list and using `awk` to search the response for the value of `platform:type` we will only get the value if it exists and the script will continue as normal if the variable is not found.
Platforms with the `platform:type` 'opencart' do not need to be updated by this module so they can be skipped in this github action.