### PR TITLE
If no transaction_id return reference_transaction_id

### DIFF
--- a/Model/Payment/Gateway/Service.php
+++ b/Model/Payment/Gateway/Service.php
@@ -200,7 +200,7 @@ class Service
             throw new LocalizedException(__('Cannot capture the order.'));
         }
         $transaction = current($body['data']['capture']['transactions']);
-        return $transaction['transaction_id'];
+        return $transaction['transaction_id'] ?? $transaction['reference_transaction_id'];
     }
 
     /**


### PR DESCRIPTION
Related to [CHK-6133](https://boldapps.atlassian.net/browse/CHK-6133)

When trying to capture a delayed capture order from the platform it would error on the first try. This was related to the capture missing a transaction_id. 

For captures the reference_transaction_id should be provided to properly tie the capture to the corresponding authorization transaction. 